### PR TITLE
refactor(authClient): update baseURL to production environment

### DIFF
--- a/src/lib/authClient.ts
+++ b/src/lib/authClient.ts
@@ -24,8 +24,8 @@ export const authClient = createAuthClient({
     }),
     nextCookies(),
   ],
-  // baseURL: 'https://ewo-backend.vercel.app',
-  baseURL: 'http://localhost:8090',
+  baseURL: 'https://ewo-backend.vercel.app',
+  // baseURL: 'http://localhost:8090',
 });
 
 export type ClientSession = typeof authClient.$Infer.Session;


### PR DESCRIPTION
- Changed the baseURL in the authClient configuration from 'http://localhost:8090' to 'https://ewo-backend.vercel.app' to ensure the application communicates with the correct production backend.
- Commented out the previous localhost URL to facilitate local development while maintaining the production settings.
- This update enhances the security and functionality of the authentication processes.