### PR TITLE
refactor(auth client): remove dynamic base URL configuration and set …

### DIFF
--- a/src/lib/authClient.ts
+++ b/src/lib/authClient.ts
@@ -4,26 +4,9 @@ import {
 } from 'better-auth/client/plugins';
 import { createAuthClient } from 'better-auth/react';
 
-// Dynamic baseURL configuration to match backend
-const getBaseURL = () => {
-  // Check if we're in a browser environment
-  if (typeof window !== 'undefined') {
-    // Use the current origin for client-side requests
-    return `${window.location.origin}`;
-  }
-
-  // Fallback for server-side rendering
-  if (process.env.NEXT_PUBLIC_API_BASE_URL) {
-    return process.env.NEXT_PUBLIC_API_BASE_URL;
-  }
-
-  // Default fallback
-  return 'https://ewo-backend.vercel.app';
-};
-
 export const authClient = createAuthClient({
-  baseURL: getBaseURL(),
-  basePath: '/api/auth',
+  // baseURL: 'http://localhost:8090',
+  baseURL: 'https://ewo-backend.vercel.app',
   // 🔑 Ensure cookies flow cross-site
   fetchOptions: {
     credentials: 'include',


### PR DESCRIPTION
…static production URL

- Removed the `getBaseURL` function from `authClient.ts`, simplifying the base URL configuration.
- Set the base URL directly to 'https://ewo-backend.vercel.app', ensuring consistent API endpoint usage.
- This change streamlines the authentication client setup, focusing on a single production environment without dynamic adjustments.