### PR TITLE
feat(auth client): add default headers for JSON requests in fetchOptions

### DIFF
--- a/src/lib/authClient.ts
+++ b/src/lib/authClient.ts
@@ -10,6 +10,10 @@ export const authClient = createAuthClient({
   // 🔑 Ensure cookies flow cross-site
   fetchOptions: {
     credentials: 'include',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
   },
 
   plugins: [


### PR DESCRIPTION
- Introduced default headers in `authClient.ts` to specify `Accept` and `Content-Type` as `application/json`.
- This change ensures that all requests made by the authentication client are properly formatted for JSON, enhancing compatibility with the API.
- The addition of these headers improves the overall robustness of the authentication process by standardizing request formats.